### PR TITLE
Switch Firebase user keys to UID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
+## Firebase Security Rules
 
+Configure your Realtime Database rules so each user can only read or write
+their own record. Use the UID based path created by the application:
+
+```json
+{
+  "rules": {
+    "users": {
+      "$uid": {
+        ".read":  "auth != null && auth.uid == $uid",
+        ".write": "auth != null && auth.uid == $uid"
+      }
+    }
+  }
+}
+```
+
+This ensures user data is accessible only to the authenticated account.

--- a/razor_server/razor_server.py
+++ b/razor_server/razor_server.py
@@ -1,6 +1,6 @@
-import os, razorpay
+import os, razorpay, time
 from fastapi import FastAPI, Request, HTTPException
-from firebase_admin import credentials, initialize_app, db
+from firebase_admin import credentials, initialize_app, db, auth
 
 # ① Replace PROJECT-ID with your Firebase project ID
 initialize_app(credentials.ApplicationDefault(),
@@ -41,9 +41,9 @@ async def webhook(req: Request):
         status = pay.get("status")
         email  = pay.get("email")
         if status == "captured" and email:
-            key = email.replace(".", "_")
+            uid = auth.get_user_by_email(email).uid
             valid_until = int(time.time() + 30*24*3600)     # +30 days
-            db.reference(f"users/{key}").update({
+            db.reference(f"users/{uid}").update({
                 "plan":            "pro",
                 "upgrade":         True,
                 "report_count":    0,


### PR DESCRIPTION
## Summary
- look up user data by UID instead of email
- store UID in session state
- adjust Razorpay webhook to resolve UID via Firebase
- document updated security rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417fe5bd60833280a75d96d919050a