### PR TITLE
Fix neon styles overriding

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,7 +67,7 @@ h1{
 /* Blue label for file uploader */
 [data-testid="stFileUploader"] label{color:#0066ff !important;}
 
-div[data-baseweb="tab"]        button{color:#000 !important;font-weight:600;}
+div[data-baseweb="tab"]        button{color:#000;font-weight:600;}
 div[data-baseweb="tab"][aria-selected="true"] button{color:#ff4f9d !important;font-weight:700;}
 div[data-baseweb="tab-highlight"]{background:#ff4f9d !important;}
 div[data-baseweb="tab"]:hover   button{color:#ff4f9d !important;}


### PR DESCRIPTION
## Summary
- avoid forced black color on tab buttons so neon styles work

## Testing
- `python -m py_compile app.py razor_server/razor_server.py firebase_config.py`


------
https://chatgpt.com/codex/tasks/task_e_6850314ab5b083329ceefd2a80a9368d