### PR TITLE
Fix indentation issue

### DIFF
--- a/app.py
+++ b/app.py
@@ -752,7 +752,6 @@ def dashboard():
             st.info(
                 "🕒 Complete payment. This page will update once the payment succeeds."
             )
-       main
             uid = S.get("uid")
             for _ in range(30):
                 time.sleep(2)
@@ -765,8 +764,7 @@ def dashboard():
             st.warning(
                 "Payment not confirmed yet. If you completed the payment, please refresh."
             )
-            
-         main
+
             st.stop()
 
     if sb.button("🚪 Logout"):


### PR DESCRIPTION
## Summary
- fix stray `main` lines causing indentation error in the dashboard logic

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687f940ec9508332ae97bbfbe4384a67