### PR TITLE
Implement email scheduling with background service

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Run the Razorpay webhook/order server:
 uvicorn razor_server.razor_server:app
 ```
 
+To deliver scheduled emails, run the background scheduler in another process:
+
+```bash
+python email_scheduler.py
+```
+
 ## UID Based Storage
 
 User records are stored in Firebase under `users/<uid>`. If you previously stored data keyed by email, create entries under the UID and copy the values over, then delete the old email-keyed nodes. This keeps all data in a single UID namespace.

--- a/email_scheduler.py
+++ b/email_scheduler.py
@@ -1,0 +1,30 @@
+import time, os, base64
+from firebase_config import firebase_config
+import pyrebase
+from app import send_email
+
+firebase = pyrebase.initialize_app(firebase_config)
+auth, db = firebase.auth(), firebase.database()
+
+# Expect EMAIL_SCHEDULER_TOKEN env for authentication
+TOKEN = os.getenv("FIREBASE_TOKEN")
+
+while True:
+    try:
+        users = db.child("users").get(TOKEN).val() or {}
+        now_ts = int(time.time())
+        for uid, rec in users.items():
+            schedules = rec.get("scheduled_emails", {})
+            for key, ev in list(schedules.items()):
+                if ev.get("send_at", 0) <= now_ts:
+                    attachments = []
+                    if ev.get("csv"):
+                        attachments.append(("report.csv", base64.b64decode(ev["csv"]), "text/csv"))
+                    if ev.get("pdf"):
+                        attachments.append(("report.pdf", base64.b64decode(ev["pdf"]), "application/pdf"))
+                    subject = ev.get("title", "Insights Report")
+                    send_email(ev.get("emails", []), subject, ev.get("insights", ""), attachments)
+                    db.child("users").child(uid).child("scheduled_emails").child(key).remove(TOKEN)
+    except Exception as e:
+        print("Scheduler error", e)
+    time.sleep(60)


### PR DESCRIPTION
## Summary
- update `send_email` to handle multiple recipients and attachments
- use `generate_insight_title` and Firebase for persistent scheduling
- show scheduled emails in **User Info** panel
- allow scheduling to multiple addresses in UI
- add `email_scheduler.py` service to process queued emails
- document scheduler in README

## Testing
- `python -m py_compile app.py email_scheduler.py razor_server/razor_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68866647ce748332a96250b8ba1f1951