### PR TITLE
Improve email error reporting

### DIFF
--- a/email_scheduler.py
+++ b/email_scheduler.py
@@ -28,13 +28,17 @@ while True:
                     if ev.get("pdf"):
                         attachments.append(("report.pdf", base64.b64decode(ev["pdf"]), "application/pdf"))
                     subject = ev.get("title", "Insights Report")
-                    success = send_email(
+                    success, err = send_email(
                         ev.get("emails", []), subject, ev.get("insights", ""), attachments
                     )
                     if success:
                         logger.info("Sent scheduled email to %s", ev.get("emails", []))
                     else:
-                        logger.error("Failed to send scheduled email to %s", ev.get("emails", []))
+                        logger.error(
+                            "Failed to send scheduled email to %s: %s",
+                            ev.get("emails", []),
+                            err,
+                        )
                     db.child("users").child(uid).child("scheduled_emails").child(key).remove(TOKEN)
     except Exception as e:
         logger.exception("Scheduler error: %s", e)


### PR DESCRIPTION
## Summary
- expose specific failure reason from `send_email`
- surface SMTP errors in the UI
- log detailed error for scheduler

## Testing
- `python -m py_compile app.py email_scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_688709b60e008332a4e733d95f6a1ba1