### PR TITLE
Fix scheduler email env loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Set the following variables before starting the app:
 - `SMTP_PASSWORD` – password for SMTP authentication.
 - `SMTP_SSL` – set to `1` to use SMTPS (optional).
 
+You can place these values in a `.env` file in the project root. Both the
+Streamlit app and the background email scheduler load this file automatically.
+
 Email recipients entered in the UI must be valid addresses. Invalid addresses
 will be highlighted before sending or scheduling.
 
@@ -51,6 +54,8 @@ To deliver scheduled emails, run the background scheduler in another process:
 ```bash
 python email_scheduler.py
 ```
+The scheduler requires a Firebase authentication token. Set it in the environment
+as `FIREBASE_TOKEN` (or add it to `.env`).
 
 ## UID Based Storage
 

--- a/email_scheduler.py
+++ b/email_scheduler.py
@@ -3,6 +3,9 @@ from firebase_config import firebase_config
 import pyrebase
 from app import send_email
 import logging
+from dotenv import load_dotenv
+
+load_dotenv()
 
 logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s - %(levelname)s - %(message)s')
@@ -11,7 +14,7 @@ logger = logging.getLogger(__name__)
 firebase = pyrebase.initialize_app(firebase_config)
 auth, db = firebase.auth(), firebase.database()
 
-# Expect EMAIL_SCHEDULER_TOKEN env for authentication
+# Expect FIREBASE_TOKEN env for authentication
 TOKEN = os.getenv("FIREBASE_TOKEN")
 
 while True:


### PR DESCRIPTION
## Summary
- load environment variables in `email_scheduler.py`
- clarify env var usage in README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68870e5123ac8332baca41a5ece8852f