### PR TITLE
Improve SMTP configuration guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Set the following variables before starting the app:
 - `SMTP_PASSWORD` – password for SMTP authentication.
 - `SMTP_SSL` – set to `1` to use SMTPS (optional).
 
+Example `.env` section for sending mail via Gmail:
+
+```env
+SMTP_SERVER=smtp.gmail.com
+SMTP_PORT=465
+SMTP_USER=your.address@gmail.com
+SMTP_PASSWORD=your_app_password
+SMTP_SSL=1
+```
+
 You can place these values in a `.env` file in the project root. Both the
 Streamlit app and the background email scheduler load this file automatically.
 

--- a/app.py
+++ b/app.py
@@ -659,7 +659,14 @@ def send_email(
         return False, err
 
     if not (server and user and pwd):
-        err = "Missing SMTP configuration"
+        missing = []
+        if not server:
+            missing.append("SMTP_SERVER")
+        if not user:
+            missing.append("SMTP_USER")
+        if not pwd:
+            missing.append("SMTP_PASSWORD")
+        err = "Missing SMTP configuration: " + ", ".join(missing)
         logger.error(err + ": server=%s user=%s", server, user)
         return False, err
 


### PR DESCRIPTION
## Summary
- clarify SMTP configuration in README with example `.env`
- show which variables are missing when email can't be sent

## Testing
- `python -m py_compile app.py email_scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_68870fd35f088332b8445c602d3dfb2f