### PR TITLE
Fix email config loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Set the following variables before starting the app:
 - `SMTP_PASSWORD` – password for SMTP authentication.
 - `SMTP_SSL` – set to `1` to use SMTPS (optional).
 
+These variables can be set as normal environment variables or placed in a
+`.env` file in the project root. The email utility automatically loads this file
+when needed so missing values won't cause errors if the file is present.
+
 Example `.env` section for sending mail via Gmail:
 
 ```env

--- a/app.py
+++ b/app.py
@@ -643,6 +643,15 @@ def send_email(
     user = os.getenv("SMTP_USER")
     pwd = os.getenv("SMTP_PASSWORD")
 
+    # Load variables from a .env file if they weren't set already. This allows
+    # ``send_email`` to be imported in isolation without the rest of ``app``
+    # having run ``load_dotenv()`` beforehand.
+    if not (server and user and pwd):
+        load_dotenv()
+        server = server or os.getenv("SMTP_SERVER")
+        user = user or os.getenv("SMTP_USER")
+        pwd = pwd or os.getenv("SMTP_PASSWORD")
+
     if isinstance(to_addrs, str):
         to_addrs = [to_addrs]
     to_addrs = [e for e in to_addrs if e]


### PR DESCRIPTION
## Summary
- load dotenv data inside `send_email` to avoid missing config errors
- document that `.env` values are loaded automatically

## Testing
- `python -m pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python -m py_compile app.py email_scheduler.py firebase_config.py razor_server/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6887117f4da08332ab58df087e157a28